### PR TITLE
replaces translateX with margins

### DIFF
--- a/src/scss/_themes.scss
+++ b/src/scss/_themes.scss
@@ -46,6 +46,7 @@
 		margin-bottom: 0;
 		padding-left: 10px;
 
+		// this adapts to fit the screen based on left o-grid-row margins
 		&:after {
 			margin-left: calc(-50vw + 5px);
 			@include oGridRespondTo(M) {

--- a/src/scss/_themes.scss
+++ b/src/scss/_themes.scss
@@ -29,11 +29,11 @@
 		position: absolute;
 		top: 0;
 		left: 50%;
+		margin-left: -50vw;
 		z-index: -1;
 		width: 100vw;
 		height: 100%;
 		background-color: $colour;
-		transform: translateX(-50%);
 	}
 }
 
@@ -47,7 +47,10 @@
 		padding-left: 10px;
 
 		&:after {
-			left: 52%;
+			margin-left: calc(-50vw + 5px);
+			@include oGridRespondTo(M) {
+				margin-left: calc(-50vw + 10px);
+			};
 		}
 
 		// modifies borders when stacked(S) and horizontal(M+)
@@ -63,7 +66,7 @@
 				padding: 0 10px;
 			};
 
-			&:nth-child(4) {
+			&:last-child {
 				border: 0;
 			}
 


### PR DESCRIPTION
The transform was leaving wiggle room in the browser as it doesn't look like things were aligning properly