### PR TITLE
Rename and consolidate content mixins.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,7 +6,12 @@ Confirm the `o-teaser-collection__heading--inverse` modifier is used with `o-tea
 
 `oTeaserCollection` has changed, it now outputs all `o-teaser-collection` css by default. See the README for `oTeaserCollection` options to include css granularly.
 
-Removes the following mixins. If your project uses these mixins replace with a single call to `oTeaserCollection` instead. See the README for `oTeaserCollection` options.
+#### Renamed Mixins
+- `oTeaserCollectionHeading` has been renamed `oTeaserCollectionContentHeading` to indicate it has no top level selector. It now excepts an `$opts` map to include parts of the heading more granularly (such as styles for a child anchor tag). See the README for more details.
+
+#### Removed Mixins
+
+If your project uses these mixins replace with a single call to `oTeaserCollection` instead. See the README for `oTeaserCollection` options.
 - oTeaserCollectionAssassination
 - oTeaserCollectionStream
 - oTeaserCollectionFrontPage
@@ -15,13 +20,36 @@ Removes the following mixins. If your project uses these mixins replace with a s
 - oTeaserCollectionItemStretched
 - oTeaserCollectionNumbered
 - oTeaserCollectionSpecial
-- oTeaserCollectionAssassination
 - oTeaserCollectionBigStory
 - oTeaserCollectionHorizontal
 - oTeaserCollectionMidSlice
 - oTeaserCollectionTopStandalone
-- oTeaserCollectionStream
-- oTeaserCollectionFrontPage
+
+
+`oTeaserCollectionHeadingLink` has also been removed. If your project is using this mixin to avoid outputting the heading border (divider) use `oTeaserCollectionContentHeading` without the `divider` or `sizes` option. This will output the base heading styles plus the child anchor styles, without the divider.
+```diff
+.my-heading {
+-   // Custom styles replicating the collection heading.
+-	@include oTypographySize(3);
+-	a {
+-		@include oTeaserCollectionHeadingLink;
+-	}
++	@include oTeaserCollectionContentHeading($opts: ('anchor': true));
+}
+```
+
+`oTeaserCollectionHeadingBorderTypography` has been removed. Replace with a call to `oTeaserCollectionContentHeading` without the `anchor` option.
+```diff
+.my-heading {
+-   @include oTeaserCollectionHeadingBorderTypography;
++	@include oTeaserCollectionContentHeading($opts: (
++       'divider': true,
++       'sizes': ('full-width', 'half-width', 'small') // .my-heading--small, etc.
++   ));
+}
+```
+
+#### Dependencies
 
 v3 updates its dependecy on `o-icons`. Confirm your project builds correctly and resolve any conflicts.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To include all styles call the `oTeaserCollection` mixin.
 @include oTeaserCollection();
 ```
 
-#### Options
+### Options
 
 `o-teaser-collection` css may be included granularly by passing options to the `oTeaserCollection` mixin.
 
@@ -63,7 +63,7 @@ To include all styles call the `oTeaserCollection` mixin.
 
 Options include:
 
-| Key                 | Possible Values                                                                                                                       | class output  |
+| Key                 | Possible Values                                                                                                                       | Classes Output  |
 |---------------------|---------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | collections         | 'horizontal', 'special', 'numbered', 'big-story', 'assassination', 'assassination-related', 'mid-slice', 'stream', 'top-standalone'   | `o-teaser-collection--[option]`. Apply to `o-teaser-collection`, e.g. `class="o-teaser-collection o-teaser-collection--horizontal"`                                  |
 | headings            | 'inverse', 'full-width', 'half-width', 'small'                                                                                        | `o-teaser-collection__heading--[option]`. Apply to `o-teaser-collection__heading`, e.g. `class="o-teaser-collection__heading o-teaser-collection__heading--inverse"` |
@@ -73,6 +73,38 @@ Options include:
 Use `o-teaser-collection--numbered` to number the list of teasers in the collection, see an [example in the registry](http://registry.origami.ft.com/components/o-teaser-collection).
 
 Use `o-teaser-collection--special` to add a darker background across the full width of the containing relative element, see an [example in the registry](http://registry.origami.ft.com/components/o-teaser-collection).
+
+
+### Headings
+
+To include heading styles output `o-teaser-collection__heading` classes using the `oTeaserCollection` mixin as described above. If your component or project would like to replicate only some parts of the heading style use `oTeaserCollectionContentHeading`.
+
+For example, to replicate only the basic heading style pass an empty map:
+```scss
+.my-heading {
+	@include oTeaserCollectionContentHeading($opts: ());
+}
+```
+
+To replicate the header fully, but without the size modifiers such as `o-teaser-collection__heading--full-width`:
+```scss
+.my-heading {
+	@include oTeaserCollectionContentHeading($opts: (
+		'anchor': true, // Include child anchor styles `.my-heading > a`
+		'divider': true, // Include the top border styles.
+		'sizes': () // Do not output size modifiers such as `.my-heading--small`.
+	));
+}
+```
+
+`oTeaserCollectionContentHeading` options include:
+
+| Key       | Possible Values                                 | Description                                                                  |
+|-----------|-------------------------------------------------|-------------------------------------------------------------------------------|
+| anchor    | Boolean                                         | Output styles for a nested anchor tag, for a collection heading with a link.  |
+| divider   | Boolean                                         | Output styles for a divider (border) above the collection heading.            |
+| sizes     | 'inverse', 'full-width', 'half-width', 'small'  | Output modifier classes for different sizes headings e.g. `my-heading--small`.|
+
 
 ## Migration
 

--- a/main.scss
+++ b/main.scss
@@ -35,7 +35,11 @@
 	}
 
 	.o-teaser-collection__heading {
-		@include oTeaserCollectionHeading($sizes: $headings);
+		@include oTeaserCollectionContentHeading($opts: (
+			'anchor': true,
+			'divider': true,
+			'sizes': $headings
+		));
 	}
 
 	.o-teaser-collection__items {

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,12 +1,39 @@
-@mixin oTeaserCollectionHeading($sizes: ('full-width', 'half-width', 'small')) {
-	@include oTeaserCollectionHeadingBorderTypography($sizes);
+/// Styles used witin o-teaser-collection__heading, including size modifiers.
+///
+/// @example - Include all heading styles.
+///		.my-collection-heading {
+///			@include oTeaserCollectionContentHeading();
+///		}
+/// @example - Include the standard heading styles but do not style any child anchor element, and do not output modifier classes for different sized headings.
+///		.my-collection-heading {
+///			@include oTeaserCollectionContentHeading($opts: (
+///				'anchor': false,
+///				'divider': true,
+///				'sizes': ()
+///			));
+///		}
+/// @example - Output a modifier class for a "small" collection heading.
+///		.my-collection-heading {
+///			@include oTeaserCollectionContentHeading($opts: (
+///				'anchor': true,
+///				'divider': true,
+///				'sizes': ('small') // .my-collection-heading--small
+///			));
+///		}
+/// @param {Map} $opts [('anchor': true,'divider': true,'sizes': ('full-width', 'half-width', 'small'))]
+@mixin oTeaserCollectionContentHeading($opts: (
+	'anchor': true,
+	'divider': true,
+	'sizes': ('full-width', 'half-width', 'small')
+)) {
+	$anchor: map-get($opts, 'anchor');
+	$divider: map-get($opts, 'divider');
 
-	a {
-		@include oTeaserCollectionHeadingLink;
-	}
-}
+	$sizes: map-get($opts, 'sizes');
+	$full-width: index($sizes, 'full-width');
+	$half-width: index($sizes, 'half-width');
+	$small: index($sizes, 'small');
 
-@mixin oTeaserCollectionHeadingBorderTypography($sizes: ('full-width', 'half-width', 'small')) {
 	@include oTypographySize(3);
 	position: relative;
 	width: 100%;
@@ -19,31 +46,33 @@
 	-webkit-font-smoothing: antialiased;
 	// sass-lint:enable no-vendor-prefixes
 
-	&:before,
-	&:after {
-		border-top: 8px solid rgba(oColorsGetPaletteColor('black'), 0.05);
-		content: '';
-		left: 0;
-		top: 0;
-		position: absolute;
-		width: 100%;
-	}
+	@if($divider) {
+		&:before,
+		&:after {
+			border-top: 8px solid rgba(oColorsGetPaletteColor('black'), 0.05);
+			content: '';
+			left: 0;
+			top: 0;
+			position: absolute;
+			width: 100%;
+		}
 
-	&:after {
-		border-top-color: oColorsGetPaletteColor('black');
+		&:after {
+			border-top-color: oColorsGetPaletteColor('black');
 
-		@include oGridRespondTo(L) {
-			width: 32.5%;
+			@include oGridRespondTo(L) {
+				width: 32.5%;
+			}
 		}
 	}
 
-	@if(index($sizes, 'full-width')) {
+	@if($divider and $full-width) {
 		&--full-width:after {
 			width: 100%;
 		}
 	}
 
-	@if(index($sizes, 'half-width')) {
+	@if($divider and $half-width) {
 		&--half-width:after {
 			@include oGridRespondTo(L) {
 				width: 49%;
@@ -51,19 +80,29 @@
 		}
 	}
 
-	@if(index($sizes, 'small')) {
+	@if($small) {
 		&--small {
 			margin-bottom: oSpacingByIncrement(5);
 			border-bottom: 1px solid $_o-teaser-collection-color-bottom-border;
 
-			&:after {
-				width: 100%;
+			@if($divider) {
+				&:after {
+					width: 100%;
+				}
 			}
+		}
+	}
+
+	@if ($anchor) {
+		> a {
+			@include _oTeaserCollectionHeadingLink;
 		}
 	}
 }
 
-@mixin oTeaserCollectionHeadingLink {
+
+/// @access private
+@mixin _oTeaserCollectionHeadingLink {
 	color: inherit;
 	text-decoration: none;
 	border: 0;


### PR DESCRIPTION
- Rename `oTeaserCollectionHeading` to `oTeaserCollectionContentHeading`.
- Remove `oTeaserCollectionHeadingLink`.
- Remove `oTeaserCollectionHeadingBorderTypography`.

The usecases for `oTeaserCollectionContentHeading` are few  and
questionable. We may want to remove this mixin in the future
after reviewing dividers with uxd.

Known uses:
oTeaserCollectionHeadingBorderTypography: [n-profile-ui](https://github.com/Financial-Times/n-profile-ui/blob/cfbb668d3a21e78e843de7311925630bfafe2995/src/scss/subheading.scss#L2)
oTeaserCollectionHeading: [newspaper-control-centre]( https://github.com/Financial-Times/newspaper-control-centre/blob/edda4bf16503c5131dde272994eb0785c61ff97f/client/heading.scss#L16) + [ft-app](https://github.com/Financial-Times/ft-app/blob/83e4c16b34f79fe2923c9361f2e315cb2bc80695/lib/css/fruit/modules/_satsuma.scss#L76)
oTeaserCollectionHeadingLink: [next-epaper](https://github.com/Financial-Times/next-epaper/blob/dcda25d6ecc63d56ff720cfe916294dbf9bfd230/client/components/first_list_title/_main.scss#L12)

Relates to: https://github.com/Financial-Times/o-teaser-collection/issues/38
Relates to: https://trello.com/c/RKBd1Q4H/39-we-need-to-talk-about-dividers