### PR TITLE
Relax the heading anchor selector

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -92,7 +92,7 @@
 	}
 
 	@if ($anchor) {
-		> a {
+		a {
 			@include _oTeaserCollectionHeadingLink;
 		}
 	}


### PR DESCRIPTION
This v3 change is causing issues across FT.com, where a .section-heading
element is often inserted wrapping a heading anchor.