### PR TITLE
Assassination related updates

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -193,6 +193,16 @@
 				.o-teaser {
 					margin-bottom: 0;
 				}
+
+				// Live timestamps are usually ordered so they move
+				// to the top of a teaser, above the heading and tag.
+				// In the assassination related section, where multiple
+				// teasers (live and not-live) are displayed in a row,
+				// the live timestamp should remain in place to align
+				// with other timestamps.
+				.o-teaser--live .o-teaser__timestamp {
+					order: initial;
+				}
 			}
 		}
 	}

--- a/main.scss
+++ b/main.scss
@@ -160,7 +160,7 @@
 
 	@if (index($collections, 'assassination-related')) {
 		.o-teaser-collection--assassination-related {
-			@include _oTeaserCollectionSpecial($_o-teaser-collection-color-assassination-bottom-bg);
+			@include _oTeaserCollectionSpecial(oColorsMix('white', 'slate', 3));
 			z-index: 1;
 			margin-bottom: 0;
 			padding-left: 10px;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -5,5 +5,4 @@ $_o-teaser-collection-color-special-bg: oColorsByName('wheat');
 $_o-teaser-collection-color-thin-border: oColorsMix(black, paper, 20);
 
 $_o-teaser-collection-color-assassination-bg: oColorsByName('slate');
-$_o-teaser-collection-color-assassination-bottom-bg: oColorsMix(white, slate, 5);
 $_o-teaser-collection-color-assassination-heading: oColorsByName('white');


### PR DESCRIPTION
**Update related assassination background colour for accessibility.**

The o-teaser timestamp and hover/visited colour does not pass
WCAG AA contrast checks when sitting on the current background.

**Update timestamp alignment for related assassination teasers.**

Live timestamps are usually ordered so they move to the top of a
teaser, above the heading and tag. In the assassination related
section, where multiple teasers (live and not-live) are displayed
in a row, the live timestamp should remain in place to align with
other timestamps.

Note the related assassination teaser collection is in a bad way.
Styles a split between o-teaser-collection and next-front-page.
It also does not conform to the current Origami specification because
it uses `o-teaser` selectors, to modify the styles of a separate
component.
https://github.com/Financial-Times/next-front-page/blob/309b844b5c25fc99fcc9cdab0152481237addf57/client/components/teaser-collections/_assassination.scss#L67